### PR TITLE
New branch: 单线程没有数据没有GUI

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -15,5 +15,9 @@ RECOMMAND_URL = ELECT_URL+'/RecommandTblOuter.aspx'
 SUMMER_URL = ELECT_URL + '/ShortSession.aspx'
 SUMMER_CHECK_URL_TEMPLATE = ELECT_URL+'/ShortSessionCheck.aspx?xklc=%d'
 SELECT_COURSE_URL = LESSON_URL+'?&xklx=&redirectForm=outSpeltyEp.aspx&kcmk=-1'
-SUMMER_SUBMIT_URL = ELECT_URL+'/什么来着我忘了.aspx'
+SUMMER_SUBMIT_URL = ELECT_URL+'/electSubmitShort.aspx?redirectForm=ShortSession.aspx'
 JACCOUNT_URL = 'https://jaccount.sjtu.edu.cn/jaccount/'
+
+TONGSHI_NAMES = ['人文学科', '社会科学', '数学或逻辑', '自然科学与']
+
+CACHE_SESSION_PATH = '/tmp/session.pickle'

--- a/utils/elector/elector.py
+++ b/utils/elector/elector.py
@@ -60,10 +60,6 @@ class SummerElector(object):
         return self.session.get(submit_response.url)
 
     def select_course_by_bsid(self, bsid):
-        ''' 给定bsid，持续选，直到成功。
-            什么情况都不报错。
-            课满了不报错，session或者__VIEWSTATE过期了更新一下继续刷，也不报错
-        '''
         self._select_course_by_bsid(bsid)
         if self.URL in self._submit().url:
             logger.info('%s submit success' % bsid)

--- a/utils/elector/elector.py
+++ b/utils/elector/elector.py
@@ -1,0 +1,95 @@
+from ..login.session import SummerSession
+from ..spider.parsers import SummerParser
+# TODO: use relative import here
+from ...settings import (SUMMER_SUBMIT_URL, SELECT_SUMMER_COURSE_URL,
+                      SUMMER_URL, TONGSHI_NAMES)
+
+from time import sleep
+import re
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# FIXME: add a factory and refactor it with spider.
+class SummerElector(object):
+    SUBMIT_URL = SUMMER_SUBMIT_URL
+    URL = SUMMER_URL
+    SLEEP_DURATION = 1.7
+    def __init__(self, username, password):
+        self.session = SummerSession(username, password)
+        self._load_db()
+        self.asp_dict = SummerParser(self.session.get(self.URL)).get_asp_args()
+
+    def get_non_full_tongshi_cid(self, wanted_types=TONGSHI_NAMES):
+        sleep(self.SLEEP_DURATION)
+        for tr in self.session.get(self.URL).text.split('<tr class="tdcolour')[1:]:
+            try:
+                cid, ctype, is_full = [tr.split('<td')[i] for i in [3, 5, 9]]
+                cid = re.search(r'\>(\w+)\s*\</td\>', cid).group(1)
+                ctype = re.search(r'\>(&?\w+;?)\s*\</td\>', ctype).group(1)
+                is_full = re.search(r'人数(\w+)\s*\</td\>', is_full).group(1) \
+                    == '满'
+                if ctype.strip() in wanted_types and not is_full:
+                    if cid != 'LA936':
+                        yield cid
+            except AttributeError:
+                pass
+
+    # TODO: Implement this with sqlite
+    def _load_db(self):
+        ''' 加载课程数据
+        '''
+        with open('/tmp/course.json', 'r') as f:
+            self.db = json.load(f)
+
+    def grab_course_by_cid(self, cid):
+        ''' 抢该课号的课程里第一个老师的课.
+        '''
+        for record in self.db:
+            if record['cid'] == cid:
+                self.select_course_by_bsid(record['bsid'])
+
+    def _submit(self):
+        ''' 进行选课提交
+        '''
+        submit_response = self.session.post(url=self.SUBMIT_URL,
+                                            data={'btnSubmit': '选课提交'},
+                                            asp_dict=self.asp_dict)
+        return self.session.get(submit_response.url)
+
+    def select_course_by_bsid(self, bsid):
+        ''' 给定bsid，持续选，直到成功。
+            什么情况都不报错。
+            课满了不报错，session或者__VIEWSTATE过期了更新一下继续刷，也不报错
+        '''
+        self._select_course_by_bsid(bsid)
+        if self.URL in self._submit().url:
+            logger.info('%s submit success' % bsid)
+        else:
+            logger.info('%s submit failed' % bsid)
+
+    def get_asp_by_bsid(self, bsid):
+        for record in self.db:
+            if record['bsid'] == bsid:
+                return record['asp']
+        raise KeyError("bsid %s not found in database." % bsid)
+
+    def _select_course_by_bsid(self, bsid):
+        return self.session.post(
+            url=SELECT_SUMMER_COURSE_URL,
+            data={'LessonTime1$btnChoose':
+                  '选定此教师', 'myradiogroup': bsid},
+            asp_dict=json.loads(self.get_asp_by_bsid(bsid)))
+
+    def run(self, wanted_types=TONGSHI_NAMES):
+        logger.debug('Elector Started...')
+        while True:
+            for cid in self.get_non_full_tongshi_cid(wanted_types):
+                self.grab_course_by_cid(cid)
+
+
+if __name__ == '__main__':
+    elector = SummerElector('username', 'password')
+    elector.run()

--- a/utils/spider/spiders.py
+++ b/utils/spider/spiders.py
@@ -47,22 +47,6 @@ class Spider(object, metaclass=ABCMeta):
         for info in self.crawl_by_course_id(course_id):
             yield {info['bsid']: info['now_number']}
 
-    def grab_course_by_bsid(self, bsid):
-        ''' 给定bsid，持续选，直到成功。
-            什么情况都不报错。
-            课满了不报错，session或者__VIEWSTATE过期了更新一下继续刷，也不报错
-        '''
-        while True:
-            response = self.session.select_course(bsid)
-            if response.url == self.url:
-                self._submit()
-                return True
-
-    def _submit(self):
-        ''' 进行选课提交
-        '''
-        self.session.head(self.SUBMIT_URL)
-
     @abstractmethod
     def crawl_one_course_by_course_id(self, course_id):
         ''' 根据课程代码爬课的信息


### PR DESCRIPTION
## Usage:

- 无脑抢课, 啥空抢啥, 冲突了就重启, 默认抢所有通识课
`
elector = SummerElector('username', 'password') elector.run()
`

- 抢bsid为123456的课:
`
elector.select_course_by_bsid(123456) # 注意这个是int型
`

## TODO:

1. 加factory
2. 和spider抽象一个基类
3. 增加查看不冲突课程的功能
4. 用sqlite代替这里直接从文件读课程的_load_db
5. 查JISP论文规划选课方式来最大化学分